### PR TITLE
path rework

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "node": ">=10.0.0"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc",
-    "build:watch": "rm -rf dist && tsc --watch",
+    "build": "rimraf dist && tsc",
+    "build:watch": "rimraf dist && tsc --watch",
     "start:alias": "es-dev-server --config demo/alias/config.js",
     "start:node-resolve": "es-dev-server --config demo/node-resolve/config.js",
     "start:inject": "es-dev-server --config demo/inject/config.js",

--- a/src/PluginContext.ts
+++ b/src/PluginContext.ts
@@ -82,7 +82,8 @@ export function createPluginContext(
         ) {
           const result = await pl.resolveImport({ source, context });
           if (result) {
-            return { id: path.resolve(importer, result) };
+            // todo: add test that verifies correctness of `path.resolve`
+            return { id: path.resolve(path.dirname(importer), result) };
           }
         }
       }

--- a/src/PluginContext.ts
+++ b/src/PluginContext.ts
@@ -4,7 +4,6 @@ import { Context } from 'koa';
 import { FSWatcher } from 'chokidar';
 import { Plugin as EdsPlugin } from 'es-dev-server';
 import { VERSION as rollupVersion } from 'rollup';
-import { URL, pathToFileURL, fileURLToPath } from 'url';
 // @ts-ignore
 import injectClassFields from 'acorn-class-fields';
 // @ts-ignore
@@ -83,8 +82,7 @@ export function createPluginContext(
         ) {
           const result = await pl.resolveImport({ source, context });
           if (result) {
-            const fileUrl = new URL(result, `${pathToFileURL(importer)}`);
-            return { id: fileURLToPath(fileUrl) };
+            return { id: path.resolve(importer, result) };
           }
         }
       }

--- a/src/PluginContext.ts
+++ b/src/PluginContext.ts
@@ -82,7 +82,6 @@ export function createPluginContext(
         ) {
           const result = await pl.resolveImport({ source, context });
           if (result) {
-            // todo: add test that verifies correctness of the joined path, ie. dirname was called
             return { id: path.join(path.dirname(importer), result) };
           }
         }

--- a/src/PluginContext.ts
+++ b/src/PluginContext.ts
@@ -82,8 +82,8 @@ export function createPluginContext(
         ) {
           const result = await pl.resolveImport({ source, context });
           if (result) {
-            // todo: add test that verifies correctness of `path.resolve`
-            return { id: path.resolve(path.dirname(importer), result) };
+            // todo: add test that verifies correctness of the joined path, ie. dirname was called
+            return { id: path.join(path.dirname(importer), result) };
           }
         }
       }

--- a/src/es-dev-server-rollup.ts
+++ b/src/es-dev-server-rollup.ts
@@ -59,7 +59,7 @@ export function wrapRollupPlugin(
       }
 
       if (! path.isAbsolute(source) && whatwgUrl.parseURL(source) != null) {
-        // don't resolve relative and valid urls 
+        // don't resolve relative and valid urls
         return source;
       }
 
@@ -154,7 +154,7 @@ export function wrapRollupPlugin(
         // if this was a special URL constructed in resolveImport to handle null bytes,
         // the file path is stored in the search paramter
         filePath = context.URL.searchParams.get(NULL_BYTE_PARAM) as string;
-      } else {path.join
+      } else {
         filePath = path.join(rootDir, context.path);
       }
 

--- a/src/es-dev-server-rollup.ts
+++ b/src/es-dev-server-rollup.ts
@@ -5,7 +5,6 @@ import {
   ParsedConfig,
   virtualFilePrefix,
 } from 'es-dev-server';
-import { URL, pathToFileURL, fileURLToPath } from 'url';
 import { Plugin as RollupPlugin, TransformPluginContext } from 'rollup';
 import {
   getTextContent,
@@ -21,11 +20,6 @@ import { createPluginContext } from './PluginContext';
 import { FSWatcher } from 'chokidar';
 
 const NULL_BYTE_PARAM = 'es-dev-server-rollup-null-byte';
-
-function resolveFilePath(rootDir: string, path: string) {
-  const fileUrl = new URL(`.${path}`, `${pathToFileURL(rootDir)}/`);
-  return fileURLToPath(fileUrl);
-}
 
 export function wrapRollupPlugin(
   rollupPlugin: RollupPlugin,
@@ -72,7 +66,7 @@ export function wrapRollupPlugin(
       const requestedFile = context.path.endsWith('/')
         ? `${context.path}index.html`
         : context.path;
-      const filePath = resolveFilePath(rootDir, requestedFile);
+      const filePath = path.join(rootDir, requestedFile);
 
       const rollupPluginContext = createPluginContext(
         fileWatcher,
@@ -160,8 +154,8 @@ export function wrapRollupPlugin(
         // if this was a special URL constructed in resolveImport to handle null bytes,
         // the file path is stored in the search paramter
         filePath = context.URL.searchParams.get(NULL_BYTE_PARAM) as string;
-      } else {
-        filePath = resolveFilePath(rootDir, context.path);
+      } else {path.join
+        filePath = path.join(rootDir, context.path);
       }
 
       const rollupPluginContext = createPluginContext(
@@ -192,7 +186,7 @@ export function wrapRollupPlugin(
       }
 
       if (context.response.is('js')) {
-        const filePath = resolveFilePath(rootDir, context.path);
+        const filePath = path.join(rootDir, context.path);
         const rollupPluginContext = createPluginContext(
           fileWatcher,
           config,
@@ -226,7 +220,7 @@ export function wrapRollupPlugin(
         const requestedFile = context.path.endsWith('/')
           ? `${context.path}index.html`
           : context.path;
-        const filePath = resolveFilePath(rootDir, requestedFile);
+        const filePath = path.join(rootDir, requestedFile);
         let changed = false;
 
         const documentAst = parseHtml(context.body);

--- a/src/es-dev-server-rollup.ts
+++ b/src/es-dev-server-rollup.ts
@@ -64,8 +64,8 @@ export function wrapRollupPlugin(
         return;
       }
 
-      if (whatwgUrl.parseURL(source) != null) {
-        // don't resolve valid urls
+      if (! path.isAbsolute(source) && whatwgUrl.parseURL(source) != null) {
+        // don't resolve relative and valid urls 
         return source;
       }
 

--- a/test/es-dev-server-rollup.test.ts
+++ b/test/es-dev-server-rollup.test.ts
@@ -264,7 +264,7 @@ describe.only('es-dev-server-rollup', () => {
       const text = await fetchText('app.js');
       expectIncludes(
         text,
-        'import "/__es-dev-server-rollup__/?null-byte=%00foo.js"'
+        'import "/__es-dev-server__/?es-dev-server-rollup-null-byte=%00foo.js"'
       );
     } finally {
       server.close();
@@ -285,7 +285,7 @@ describe.only('es-dev-server-rollup', () => {
     });
 
     try {
-      const text = await fetchText('__es-dev-server-rollup__/?null-byte=%00foo.js');
+      const text = await fetchText('__es-dev-server__/?es-dev-server-rollup-null-byte=%00foo.js');
       expectIncludes(
         text,
         'console.log("foo");'

--- a/test/es-dev-server-rollup.test.ts
+++ b/test/es-dev-server-rollup.test.ts
@@ -83,6 +83,27 @@ describe.only('es-dev-server-rollup', () => {
         server.close();
       }
     });
+
+    it('can resolve imports with plugins that use the `resolve` helper', async () => {
+      const file = '../../hello.js';
+      const plugin: RollupPlugin = {
+        name: 'my-plugin',
+        async resolveId(id, importer) {
+          if(id === file) return id;
+          return await this.resolve(file, importer, { skipSelf: false });
+        },
+      };
+      const server = await setupServer({
+        plugins: [wrapRollupPlugin(plugin)],
+      });
+
+      try {
+        const text = await fetchText('app.js');
+        expectIncludes(text, `import moduleA from '${path.resolve('hello.js')}'`);
+      } finally {
+        server.close();
+      }
+    });
   });
 
   describe('load', () => {


### PR DESCRIPTION
This PR will rework how paths are computed. The change should fix issues on Windows and simplify the internal code by removing the usage of file URLS.

- [x] make tests work again
- [x] rewrite without file URL
- [x] test on Windows
- [ ] test on Unix system
- [ ] ~add specific Windows tests~
- [x] add test for `this.resolve` helper